### PR TITLE
add reduced animation toggle and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
 </head>
 
 <body>
+    <label id="reduced-animation-container" for="reduced-animation">
+        Reduced Animation
+        <input type="checkbox" id="reduced-animation" class="checkbox" />
+    </label>
     <div class="zapper"></div>
     <div class="play-area"></div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -105,6 +105,22 @@ function showStart() {
 }
 
 function initialiseGame() {
+  const reducedAnimationInput = document.querySelector("#reduced-animation");
+  reducedAnimationInput.addEventListener("change", (event) => {
+    if (event.target.checked) {
+      document.documentElement.setAttribute("data-reduced-animation", "true");
+      localStorage.setItem("reduced-animation", "true");
+    } else {
+      document.documentElement.removeAttribute("data-reduced-animation");
+      localStorage.removeItem("reduced-animation");
+    }
+  });
+
+  if (localStorage.getItem("reduced-animation") === "true") {
+    reducedAnimationInput.checked = true;
+    document.documentElement.setAttribute("data-reduced-animation", "true");
+  }
+
   showStart();
 
   let target = document.createElement("div");

--- a/style.css
+++ b/style.css
@@ -80,6 +80,10 @@ div.instructions {
     animation: flicker 0.2s infinite;
 }
 
+[data-reduced-animation="true"] .zapper {
+    animation: none;
+}
+
 @keyframes flicker {
 
     0%,
@@ -190,9 +194,29 @@ div.instructions {
     background-color: transparent;
 }
 
+[data-reduced-animation="true"] .vibrating {
+    animation: none;
+}
+
 .zapping {
     animation: zapping 0.4s infinite linear;
     background-color: transparent;
+}
+
+[data-reduced-animation="true"] .zapping {
+    animation: zapping 1s infinite linear !important;
+}
+
+#reduced-animation-container {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    padding: 5px 10px;
+    border-radius: 5px;
+    font-family: "Bebas Neue", serif;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: white;
+    user-select: none;
 }
 
 @keyframes vibrate {


### PR DESCRIPTION
This pull request allows the users to enable a "reduced animation" mode.
In that mode the zapper flickering and the rapid movement of the mosquito are disabled.

This improves accessibility and reduces visual strain for users sensitive to motion.